### PR TITLE
修复在某些情况下sidebar的badge会出现全部显示的情况

### DIFF
--- a/layout/_partial/sidebar.ejs
+++ b/layout/_partial/sidebar.ejs
@@ -14,16 +14,16 @@
       <% var classname = "list-group-item"; %>
       <% if(url_for(page.path)==url_for(theme.Menu[name])){classname = "list-group-item-current";} %>
   	  <a class="<%- classname %>" href="<%- url_for(theme.Menu[name]) %>"><div><i class="fa <%- theme.icon[name] %> fa-fw"></i>&nbsp; <%- __('Menu.' + name) %></div>
-      <div class="badge">
+        
         <% if(theme.sidebar_num){ %>
           <% if(name=="Archives"){ %>
-  	    	  <%- site.posts.length %>
+  	    	  <div class="badge"><%- site.posts.length %></div>
           <% }else if(name=="Tags"){ %>
-  	    	  <%- site.tags.length %>
+  	    	  <div class="badge"><%- site.tags.length %></div>
           <% }else if(name=="Categories"){ %>
-  	    	  <%- site.categories.length %>
+  	    	  <div class="badge"><%- site.categories.length %></div>
           <% }else{}} %>
-      </div></a>
+      </a>
     <% } %>
     <div style="height: 200px;"></div>
   </div>


### PR DESCRIPTION
如题

修复前：
![image](https://github.com/user-attachments/assets/cf554c46-bf47-4393-b58a-46fa13ed3847)


修复后：
![image](https://github.com/user-attachments/assets/0456ccbf-2217-41c7-99db-9b3f9c2766c5)
